### PR TITLE
Enable no demo course case

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,7 +48,8 @@ training-platform.code-workspace
 /bddScripts
 
 /pdfs
-/courses
+/courses/*
+!/courses/.gitkeep
 
 #github actions deploy
 .github/workflows/deploy.yml

--- a/next.config.js
+++ b/next.config.js
@@ -12,4 +12,6 @@ const SentryWebpackPluginOptions = {
   // For all available options, see:
   // https://github.com/getsentry/sentry-webpack-plugin#options.
 };
-module.exports = withSentryConfig(configWithMDX, SentryWebpackPluginOptions);
+module.exports = process.env.SENTRY_AUTH_TOKEN
+  ? withSentryConfig(configWithMDX, SentryWebpackPluginOptions)
+  : configWithMDX;

--- a/src/components/course/NoCourse.tsx
+++ b/src/components/course/NoCourse.tsx
@@ -3,7 +3,7 @@ import { useSession } from "next-auth/client";
 import { CourseType } from "src/pages";
 import CourseDetail from "./CourseDetail";
 
-const NoCourse = ({ demoCourse }: { demoCourse: CourseType }) => {
+const NoCourse = ({ demoCourse }: { demoCourse?: CourseType }) => {
   const [session, _] = useSession();
   return (
     <>
@@ -32,7 +32,7 @@ const NoCourse = ({ demoCourse }: { demoCourse: CourseType }) => {
           </Box>
         </Stack>
 
-        <CourseDetail course={demoCourse} />
+        {demoCourse && <CourseDetail course={demoCourse} />}
       </SimpleGrid>
     </>
   );

--- a/src/components/homes/ConnectedHome.tsx
+++ b/src/components/homes/ConnectedHome.tsx
@@ -9,7 +9,7 @@ const ConnectedHome = ({
   demoCourse,
 }: {
   courses: CourseType[];
-  demoCourse: CourseType;
+  demoCourse?: CourseType;
 }) => {
   const [session, _] = useSession();
 

--- a/src/components/mdx/ChapterHeadingBackground.tsx
+++ b/src/components/mdx/ChapterHeadingBackground.tsx
@@ -8,8 +8,6 @@ const ChapterDefaultBg: React.FC = ({}) => {
     return `linear(${directions[i]}, ${color}.600, transparent 50% )`;
   });
 
-  const myBgPattern = require("../../../courses/assets/backgrounds/pattern.svg");
-
   return (
     <Flex
       position="absolute"
@@ -24,7 +22,6 @@ const ChapterDefaultBg: React.FC = ({}) => {
             position="absolute"
             minHeight="100%"
             minWidth="100%"
-            bgImage={myBgPattern}
             bgRepeat="repeat"
             filter={`opacity(8%)`}
           >

--- a/src/utils/courses.ts
+++ b/src/utils/courses.ts
@@ -2,7 +2,7 @@ import { CourseType } from "src/pages";
 
 export const getCourseCover = (course: CourseType) => {
   const cover = require(`../../courses/${
-    course.info?.courseFile ?? course?.title
+    course?.info?.courseFile ?? course?.title
   }/assets/cover.png`);
   return encodeURI(cover.default.src);
 };


### PR DESCRIPTION
Home page should be displayed even if no demo course is provided. 
Should only scan courses directories and not files (DS_Store or .gitkeep files)