### PR TITLE
Fix slides navigation

### DIFF
--- a/prisma/migrations/20221005085048_add_chapters_infos/migration.sql
+++ b/prisma/migrations/20221005085048_add_chapters_infos/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Training" ADD COLUMN     "chaptersInfo" JSONB;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -71,4 +71,5 @@ model Training {
   updatedAt    DateTime @updatedAt
   userId       String
   author         User     @relation(fields: [userId], references: [id])
+  chaptersInfo Json?
 }

--- a/src/components/course/ChapterInfosField.tsx
+++ b/src/components/course/ChapterInfosField.tsx
@@ -1,0 +1,33 @@
+import { Box, Input, Textarea } from "@chakra-ui/react";
+import { useFieldArray, useFormContext } from "react-hook-form";
+
+const FieldArray = () => {
+  const { control, register } = useFormContext();
+  const { fields } = useFieldArray({
+    control,
+    name: "chaptersInfo",
+  });
+
+  return (
+    <>
+      {fields.map((_, index) => (
+        <>
+          <Input
+            placeholder="Chapitre"
+            size="md"
+            {...register(`chaptersInfo.${index}.title`)}
+          />
+          <Box pl={6}>
+            <Textarea
+              fontSize="sm"
+              placeholder="Description du chapitre"
+              {...register(`chaptersInfo.${index}.description`)}
+            />
+          </Box>
+        </>
+      ))}
+    </>
+  );
+};
+
+export default FieldArray;

--- a/src/components/course/CourseDetail.tsx
+++ b/src/components/course/CourseDetail.tsx
@@ -1,13 +1,23 @@
-import { Button, Box, Icon, Text, HStack, Image } from "@chakra-ui/react";
+import {
+  Button,
+  Box,
+  Icon,
+  Text,
+  HStack,
+  Image,
+  UnorderedList,
+  ListItem,
+} from "@chakra-ui/react";
 import router from "next/router";
 import { useState } from "react";
 import { MdFileDownload, MdPlayCircleOutline } from "react-icons/md";
 import { CourseType } from "src/pages";
 import { getCourseCover } from "src/utils/courses";
-import CourseMapPreview from "../CourseMapPreview";
+import { ChapterInfo } from "./CourseForm";
 
 const CourseDetail = ({ course }: { course: CourseType }) => {
   const [loadingPdf, setLoadingPdf] = useState(false);
+  const chaptersInfo = course?.chaptersInfo as ChapterInfo[];
   return (
     <Box
       background="white"
@@ -52,7 +62,21 @@ const CourseDetail = ({ course }: { course: CourseType }) => {
         </Button>
       </HStack>
       <Text paddingY={10}>{course?.description}</Text>
-      {course?.courseMap && <CourseMapPreview course={course} />}
+      <Text paddingTop={4} fontWeight="bold" fontSize="md" paddingBottom={4}>
+        Plan du cours
+      </Text>
+      <UnorderedList>
+        {chaptersInfo?.map(({ title, description }, idx) => (
+          <ListItem key={idx}>
+            <Text fontSize="sm" fontWeight="bold">
+              {title}
+            </Text>
+            <Text fontSize="sm" paddingLeft={2} paddingBottom={2}>
+              {description}
+            </Text>
+          </ListItem>
+        ))}
+      </UnorderedList>
     </Box>
   );
 };

--- a/src/components/course/CourseForm.tsx
+++ b/src/components/course/CourseForm.tsx
@@ -8,6 +8,7 @@ import { useRouter } from "next/router";
 import SwitchField from "../fields/SwitchField";
 import { Training } from "@prisma/client";
 import { useSession } from "next-auth/client";
+import { CopyIcon } from "@chakra-ui/icons";
 
 interface ICourseFormProps {
   course?: Training;
@@ -57,6 +58,29 @@ const CourseForm = ({ course }: ICourseFormProps) => {
 
   return (
     <Box>
+      <Center>
+        {course && (
+          <Button
+            colorScheme="secondary"
+            variant="solid"
+            border="1px"
+            fontSize="sm"
+            mx="sm"
+            leftIcon={<CopyIcon />}
+            onClick={() =>
+              router.push({
+                pathname: "/admin/courses/[slug]/[chapterKey]",
+                query: {
+                  slug: course?.slug,
+                  chapterKey: 0,
+                },
+              })
+            }
+          >
+            Editer le contenu
+          </Button>
+        )}
+      </Center>
       <FormProvider {...methods}>
         <form onSubmit={handleSubmit(onSubmit)}>
           <Stack spacing={6}>
@@ -67,21 +91,6 @@ const CourseForm = ({ course }: ICourseFormProps) => {
               label="Autoriser le téléchargement PDF"
             />
             <Center>
-              {course && (
-                <Button
-                  colorScheme="orange"
-                  variant="solid"
-                  border="1px"
-                  fontSize="sm"
-                  mx="sm"
-                  onClick={() =>
-                    router.push("/admin/courses/" + course!.id + "/0")
-                  }
-                >
-                  Editer le contenu
-                </Button>
-              )}
-
               <Button
                 type="submit"
                 colorScheme="primary"

--- a/src/components/course/CoursesTable.tsx
+++ b/src/components/course/CoursesTable.tsx
@@ -1,4 +1,4 @@
-import { CloseIcon, EditIcon } from "@chakra-ui/icons";
+import { CloseIcon, EditIcon, ViewIcon } from "@chakra-ui/icons";
 import {
   HStack,
   IconButton,
@@ -57,6 +57,15 @@ const CoursesTable = ({ courses }: ICoursesTableProps) => {
             <Td>{course?.author?.email}</Td>
             <Td justifyContent="flex-end">
               <HStack>
+                <Tooltip label="Voir le cours">
+                  <IconButton
+                    size="sm"
+                    aria-label="View"
+                    icon={<ViewIcon />}
+                    as={Link}
+                    href={`/${course.slug}/0`}
+                  />
+                </Tooltip>
                 <Tooltip label="Éditer les infos">
                   <IconButton
                     size="sm"

--- a/src/components/course/CoursesTable.tsx
+++ b/src/components/course/CoursesTable.tsx
@@ -9,6 +9,7 @@ import {
   Text,
   Th,
   Thead,
+  Tooltip,
   Tr,
 } from "@chakra-ui/react";
 import { useRouter } from "next/router";
@@ -56,13 +57,15 @@ const CoursesTable = ({ courses }: ICoursesTableProps) => {
             <Td>{course?.author?.email}</Td>
             <Td justifyContent="flex-end">
               <HStack>
-                <IconButton
-                  size="sm"
-                  aria-label="Search database"
-                  icon={<EditIcon />}
-                  as={Link}
-                  href={`/admin/courses/${course.id}`}
-                />
+                <Tooltip label="Éditer les infos">
+                  <IconButton
+                    size="sm"
+                    aria-label="Edit info"
+                    icon={<EditIcon />}
+                    as={Link}
+                    href={`/admin/courses/${course.slug}`}
+                  />
+                </Tooltip>
                 <ConfirmButton
                   label="Supprimer le cours"
                   confirmDetail="Êtes-vous sûrs de vouloir supprimer ce cours?"

--- a/src/components/mdx/ChaptersMenu.tsx
+++ b/src/components/mdx/ChaptersMenu.tsx
@@ -2,6 +2,7 @@ import { Box, Flex, Heading, Text } from "@chakra-ui/layout";
 import { useRouter } from "next/router";
 import { useSocketContext } from "@/context/SocketContext";
 import { CourseType } from "src/pages";
+import { ChapterInfo } from "../course/CourseForm";
 
 export interface ChaptersMenuProps {
   course: CourseType;
@@ -16,7 +17,7 @@ const ChaptersMenu: React.FC<ChaptersMenuProps> = ({
 }) => {
   const router = useRouter();
   const { pushSlide } = useSocketContext();
-
+  const chaptersInfo = course?.chaptersInfo as ChapterInfo[];
   const handleChapterClick = (chapter: string) => {
     pushSlide({
       course: course?.slug,
@@ -64,7 +65,9 @@ const ChaptersMenu: React.FC<ChaptersMenuProps> = ({
             }}
             onClick={() => handleChapterClick(chapter)}
           >
-            <Text fontSize="xs">Chapitre {i + 1}</Text>
+            <Text fontSize="xs">
+              {chaptersInfo[i]?.title ?? `Chapitre ${i + 1}`}
+            </Text>
             <Text fontWeight="bold" fontSize="lg">
               {chapter.replace(/^[\d-]*\s*/, "")}
             </Text>

--- a/src/components/users/UserForm.tsx
+++ b/src/components/users/UserForm.tsx
@@ -56,7 +56,7 @@ const UserForm = ({ user, courses, onSuccess }: Props) => {
     defaultValues: getInitialValues(),
   });
 
-  const { handleSubmit } = methods;
+  const { handleSubmit, setError } = methods;
 
   const onSubmit = async (data: any) => {
     const courses = data?.courses?.map((course: Training) => course?.id);
@@ -75,7 +75,8 @@ const UserForm = ({ user, courses, onSuccess }: Props) => {
             isClosable: true,
           });
         });
-        methods.setError("email", {
+        //@ts-ignore
+        setError("email", {
           type: "custom",
           message: "Changer l'email",
         });

--- a/src/context/SlidesContext.tsx
+++ b/src/context/SlidesContext.tsx
@@ -84,7 +84,7 @@ export function SlidesProvider({
         );
       }
     }
-  }, [totalSlides]);
+  }, [totalSlides, currentSlide]);
 
   const swipeHandlers = useSwipeable({
     onSwipedLeft: () => {

--- a/src/pages/admin/courses/[slug]/index.tsx
+++ b/src/pages/admin/courses/[slug]/index.tsx
@@ -40,10 +40,10 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
     return redirect;
   }
 
-  const id = context.params!.id as string;
+  const slug = context.params!.slug as string;
   const course = await prisma.training.findUnique({
     where: {
-      id,
+      slug,
     },
   });
 

--- a/src/pages/admin/courses/[slug]/index.tsx
+++ b/src/pages/admin/courses/[slug]/index.tsx
@@ -5,8 +5,13 @@ import { GetServerSidePropsContext } from "next";
 import { checkIsConnected } from "src/utils/auth";
 import { inferSSRProps } from "@/lib/inferNextProps";
 import prisma from "@/lib/prisma";
+import fs from "fs";
+import path from "path";
 
-const EditCourse = ({ course }: inferSSRProps<typeof getServerSideProps>) => {
+const EditCourse = ({
+  course,
+  chaptersCount,
+}: inferSSRProps<typeof getServerSideProps>) => {
   return (
     <Layout title="Cours">
       <Center mx={"auto"} my={"8"} borderWidth="1px" borderRadius={"md"}>
@@ -25,7 +30,7 @@ const EditCourse = ({ course }: inferSSRProps<typeof getServerSideProps>) => {
           >
             Éditer le Cours
           </Heading>
-          <CourseForm course={course} />
+          <CourseForm course={course} chaptersCount={chaptersCount} />
         </Flex>
       </Center>
     </Layout>
@@ -35,6 +40,7 @@ const EditCourse = ({ course }: inferSSRProps<typeof getServerSideProps>) => {
 export default EditCourse;
 
 export async function getServerSideProps(context: GetServerSidePropsContext) {
+  let chaptersCount = 0;
   const redirect = await checkIsConnected({ context, staffOnly: true });
   if (redirect) {
     return redirect;
@@ -54,9 +60,13 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
         permanent: false,
       },
     };
+  } else {
+    chaptersCount = fs
+      .readdirSync(path.join(process.cwd(), "courses", `${course.slug}`))
+      .filter((name) => name.endsWith(".mdx"))?.length;
   }
 
   return {
-    props: { course },
+    props: { course, chaptersCount },
   };
 }

--- a/src/pages/admin/courses/index.tsx
+++ b/src/pages/admin/courses/index.tsx
@@ -3,17 +3,24 @@ import Layout from "@/components/Layout";
 import { MessageData } from "@/components/users/Message";
 import { inferSSRProps } from "@/lib/inferNextProps";
 import prisma from "@/lib/prisma";
-import { MdAddCircleOutline } from "react-icons/md";
-import { Box, Button, Center, Heading, VStack, Text } from "@chakra-ui/react";
+// import { MdAddCircleOutline } from "react-icons/md";
+import {
+  Box,
+  // Button,
+  Center,
+  Heading,
+  VStack,
+  Text,
+} from "@chakra-ui/react";
 import { GetServerSidePropsContext } from "next";
-import { useRouter } from "next/router";
+// import { useRouter } from "next/router";
 import { checkIsConnected } from "src/utils/auth";
 import { getSession } from "next-auth/client";
 
 const LIMIT = 10;
 
 const CoursesPage = ({ courses }: inferSSRProps<typeof getServerSideProps>) => {
-  const router = useRouter();
+  // const router = useRouter();
   return (
     <Layout title="Cours">
       <Center mx={"auto"} my={"8"} borderWidth="1px" borderRadius={"md"}>
@@ -27,7 +34,7 @@ const CoursesPage = ({ courses }: inferSSRProps<typeof getServerSideProps>) => {
           <Heading size="md" textAlign="center" paddingX="10">
             Liste des Cours
           </Heading>
-          <Box>
+          {/* <Box>
             <Button
               colorScheme="primary"
               onClick={() => router.push("/admin/courses/create")}
@@ -35,7 +42,7 @@ const CoursesPage = ({ courses }: inferSSRProps<typeof getServerSideProps>) => {
             >
               Ajouter un cours
             </Button>
-          </Box>
+          </Box> */}
           <Box>
             {courses?.length ? (
               <CoursesTable courses={courses} />


### PR DESCRIPTION
- fix du passage au slides bloqué à 999 quand on revient en arrière
- fix du refresh du contenu sur l'édition de slide
- fix de l'usage des slugs dans les urls

Formulaire dans l'édition de cours
<img width="834" alt="image" src="https://user-images.githubusercontent.com/25606391/194079369-39e4f402-6ae4-4c39-a039-f61e8d686a37.png">

Par défaut on remplit les champs avec le titre Chapitre 1, Chapitre 2...
<img width="868" alt="image" src="https://user-images.githubusercontent.com/25606391/194079570-e43711f6-ca90-4816-9e12-53cb62adec81.png">


Affichage dans le détail
<img width="1019" alt="image" src="https://user-images.githubusercontent.com/25606391/194079216-d090a3f2-8e06-4278-8ffc-d978ee64417f.png">


Affichage dans la nav
<img width="327" alt="image" src="https://user-images.githubusercontent.com/25606391/194079126-f0ae5739-3d81-4b1a-91e6-5d63f6aecd9c.png">
